### PR TITLE
Upgrade sitemap_generator gem to version 4.0.1

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= 1.0.0'
-  s.add_dependency 'sitemap_generator', '~> 3.1'
+  s.add_dependency 'sitemap_generator', '~> 4.0.1'
 
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'


### PR DESCRIPTION
This brings in the following changes to sitemap generator:

v4.0.1: Add a post install message regarding the naming convention change.
v4.0: NEW, NON-BACKWARDS COMPATIBLE CHANGES. See above for more info. create_index defaults to :auto. Define SitemapGenerator::SimpleNamer class for simpler custom namers compatible with the new naming conventions. Deprecate sitemaps_namer, sitemap_index_namer and their respective namer classes. It's more just that their usage is discouraged. Support nofollow option on alternate links. Fix formatting of publication_date in News sitemaps.
v3.4: Support alternate links for urls; Support configurable options in the SitemapGenerator::S3Adapter
v3.3: Support creating sitemaps with no index file. A big thank-you to Eric Hochberger for generously paying for this feature.
v3.2.1: Fix syntax error in SitemapGenerator::S3Adapter
v3.2: Support mobile tags, SitemapGenerator::S3Adapter a simple S3 adapter which uses Fog and doesn't require CarrierWave; Remove Ask from the sitemap ping because the service has been shutdown; Turn off include_index by default; Fix the news XML namespace; Only include autoplay attribute if present
v3.1.1: Bugfix: Groups inherit current adapter
