### PR TITLE
Update sitemap_generator to 4.2.0

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= 1.0.0'
-  s.add_dependency 'sitemap_generator', '~> 4.1.0'
+  s.add_dependency 'sitemap_generator', '~> 4.2.0'
 
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'


### PR DESCRIPTION
Update required to fix failure to generate valid map on sites with more than 50k links.
