### PR TITLE
Gemspec, Rakefile, and spec changes to run with 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-
-gem 'spree', github: 'spree/spree', branch: 'master'
-
 gemspec
+
+gem 'spree', github: 'spree/spree', branch: '1-3-stable'

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/common_rake'
+require 'spree/core/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,14 +15,14 @@ require 'ffaker'
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
-require 'spree/testing_support/factories'
-require 'spree/testing_support/controller_requests'
-require 'spree/testing_support/url_helpers'
+require 'spree/core/testing_support/factories'
+require 'spree/core/testing_support/controller_requests'
+require 'spree/core/url_helpers'
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
-  config.include Spree::TestingSupport::UrlHelpers
-  config.include Spree::TestingSupport::ControllerRequests
+  config.include Spree::Core::UrlHelpers
+  config.include Spree::Core::TestingSupport::ControllerRequests
 
   config.use_transactional_fixtures = false
 

--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_core', '~> 2.3.0.beta'
+  s.add_runtime_dependency 'spree_core', '~> 1.3.0'
   s.add_runtime_dependency 'sitemap_generator', '~> 4.3.1'
 
   s.add_development_dependency 'database_cleaner', '~> 1.2.0'


### PR DESCRIPTION
The extension works fine with 1.3 with a couple modifications. Would be great to have a 1-3-stable branch.
