### PR TITLE
Bump dependency from 3.0.0.rc to 3.0.0

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_core', '~> 3.0.0.rc3'
+  s.add_runtime_dependency 'spree_core', '~> 3.0.0'
   s.add_runtime_dependency 'sitemap_generator', '~> 4.3.1'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'


### PR DESCRIPTION
The gemspec had a dependency on the release-candidate. Since 3.0.x is out, it makes sense to make the dependency less strict.