### PR TITLE
missing method gem_available? added to make code work with latest spree 3.1

### DIFF
--- a/lib/spree_sitemap/spree_defaults.rb
+++ b/lib/spree_sitemap/spree_defaults.rb
@@ -1,6 +1,6 @@
 module SpreeSitemap::SpreeDefaults
   include Spree::Core::Engine.routes.url_helpers
-  include Spree::BaseHelper # for gem_available? + meta_data
+  include Spree::BaseHelper # for meta_data
 
   def default_url_options
     { host: SitemapGenerator::Sitemap.default_host }
@@ -65,6 +65,14 @@ module SpreeSitemap::SpreeDefaults
   def add_taxon(taxon, options = {})
     add(nested_taxons_path(taxon.permalink), options.merge(lastmod: taxon.products.last_updated))
     taxon.children.each { |child| add_taxon(child, options) }
+  end
+
+  def gem_available?(name)
+    Gem::Specification.find_by_name(name)
+  rescue Gem::LoadError
+    false
+  rescue
+    Gem.available?(name)
   end
 
   private

--- a/spec/lib/spree_sitemap/spree_defaults_spec.rb
+++ b/spec/lib/spree_sitemap/spree_defaults_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe SpreeSitemap::SpreeDefaults do
     end
   end
 
+  context '.gem_available?' do
+    it 'verifies that gem is available' do
+      expect(subject.gem_available?('rspec-rails')).to be_truthy
+    end
+
+    context 'when there is no such gem' do
+      it 'returns false' do
+        expect(subject.gem_available?('fake_spree_gem_name')).to be false
+      end
+    end
+  end
+
   skip '.add_login(options = {})'
   skip '.add_signup(options = {})'
   skip '.add_account(options = {})'


### PR DESCRIPTION
In Spree PR https://github.com/spree/spree/pull/5920 method `gem_available?` was removed from BaseHelper. Since spre_sitemap uses it to detect features we need it back. 

I added it in this PR with appropriate tests. 