### PR TITLE
Fixes #18

### DIFF
--- a/lib/spree_sitemap/spree_defaults.rb
+++ b/lib/spree_sitemap/spree_defaults.rb
@@ -75,6 +75,10 @@ module SpreeSitemap::SpreeDefaults
     Gem.available?(name)
   end
 
+  def main_app
+    Rails.application.routes.url_helpers
+  end
+
   private
 
   ##

--- a/spec/lib/spree_sitemap/spree_defaults_spec.rb
+++ b/spec/lib/spree_sitemap/spree_defaults_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe SpreeSitemap::SpreeDefaults do
     end
   end
 
+  describe '.main_app' do
+    context 'returns the url helpers module for the application' do
+      it { expect(subject.main_app).to respond_to(:url_for, :spree_path, :_routes) }
+    end
+  end
+
   skip '.add_login(options = {})'
   skip '.add_signup(options = {})'
   skip '.add_account(options = {})'

--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'pry-rails'
   s.add_development_dependency 'rubocop', '>= 0.24.1'
+  s.add_development_dependency 'coffee-script', '~> 2.4.1'
 end


### PR DESCRIPTION
To add routes outside of spree we can now use main_app as sitemap_generator does not use url_helpers module and spree_sitemap uses spree engine's url_helpers module.

Add dependency for coffee-rails to fix test_app build...
Add main_app method to spree_defaults module...
Update rspecs
