### PR TITLE
to use sitemap_generator 5.1.0

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_runtime_dependency 'spree_core', '~> 3.1.0.beta'
-  s.add_runtime_dependency 'sitemap_generator', '~> 5.0.0'
+  s.add_runtime_dependency 'sitemap_generator', '~> 5.1.0'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'
   s.add_development_dependency 'factory_girl', '~> 4.4'


### PR DESCRIPTION
sitemap_generator 5.1.0 have some important update.
we can use fog_aws instead of fog.