### PR TITLE
Use find_each when looping through products

### DIFF
--- a/lib/spree_sitemap/spree_defaults.rb
+++ b/lib/spree_sitemap/spree_defaults.rb
@@ -26,7 +26,7 @@ module SpreeSitemap::SpreeDefaults
     active_products = Spree::Product.active.uniq
 
     add(products_path, options.merge(lastmod: active_products.last_updated))
-    active_products.each do |product|
+    active_products.find_each do |product|
       add_product(product, options)
     end
   end


### PR DESCRIPTION
- Won't load all products in memory, but will load them in chunks
  of 1000.
- Better for sites with lots of products

Edit: Travis error seems unrelated to the change.
