### PR TITLE
set spree_core to point at >=3.1.0 and < 4.0

### DIFF
--- a/spree_sitemap.gemspec
+++ b/spree_sitemap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 4.0'
   s.add_runtime_dependency 'sitemap_generator', '~> 5.1.0'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.