### PR TITLE
Don't prepend "http"

### DIFF
--- a/lib/generators/templates/config/sitemap.rb
+++ b/lib/generators/templates/config/sitemap.rb
@@ -1,4 +1,4 @@
-SitemapGenerator::Sitemap.default_host = "http://#{Spree::Store.default.url}"
+SitemapGenerator::Sitemap.default_host = Spree::Store.default.url
 
 ##
 ## If using Heroku or similar service where you want sitemaps to live in S3 you'll need to setup these settings.


### PR DESCRIPTION
This doesn't work when the website is on https and means you have to change the settings in every config that uses it instead of setting it once in Spree::Store.default.url